### PR TITLE
Fix: task salary bugs

### DIFF
--- a/components/PostTask/Form.vue
+++ b/components/PostTask/Form.vue
@@ -124,12 +124,12 @@ const dev = process.dev
 
 
 // - loading -
-function openLoading(option) {
+function openLoading (option) {
     _storeFullOverlay.open()
     btnDisabled.value = true
     openBtnLoading(option)
 }
-function closeLoading() {
+function closeLoading () {
     _storeFullOverlay.close()
     btnDisabled.value = false
     closeBtnLoading()
@@ -162,6 +162,13 @@ const setCurrentRules = (submitter) => {
         case postTaskConfig.taskSubmitter.published:
         case postTaskConfig.taskSubmitter.publishFromDraft:
             currentRules.value = postTaskConfig.rules.publish;
+            console.log('1', currentRules.value);
+            //增加任務薪水檢查規則
+            const index = currentRules.value.salary.findIndex((item) => item == 'checkUserCoin')
+            if (index >= 0) {
+                currentRules.value.salary[index] = (v) => v <= userCoin.value.superCoin || `不可超過目前帳戶儲值餘額 ${userCoin.value.superCoin} 點超人幣`
+            }
+            console.log('2', currentRules.value);
             break;
         case postTaskConfig.taskSubmitter.unpublished:
             currentRules.value = postTaskConfig.rules.unpublish;
@@ -357,7 +364,7 @@ const Init = () => {
 
     let promiseArr = [
         excuteAsyncFunc(_work, getAccountInfo, null, (response) => {
-            if(response && checkRespStatus(response)){
+            if (response && checkRespStatus(response)) {
                 const data = response.data;
                 locationData.value = data.location;
                 contactInfoData.value = {
@@ -374,11 +381,7 @@ const Init = () => {
         }),
         excuteAsyncFunc(_work, getAccountPoints, null, (response) => {
             userCoin.value = response.data
-            //增加任務薪水檢查規則
-            const index = currentRules.value.salary.findIndex((item) => item == 'checkUserCoin')
-            if (index >= 0) {
-                currentRules.value.salary[index] = (v) => v <= userCoin.value.superCoin || `不可超過目前帳戶儲值餘額 ${userCoin.value.superCoin} 點超人幣`
-            }
+
         })
     ]
 
@@ -426,7 +429,7 @@ onMounted(() => {
 })
 
 // - 假資料 -
-function fakeData() {
+function fakeData () {
     formData.value.title = '測試任務'
     formData.value.category = '到府驅蟲'
     formData.value.description = 'test'

--- a/composables/useFormUtil.js
+++ b/composables/useFormUtil.js
@@ -24,11 +24,12 @@ export const useFormUtil = () => {
       .then((res) => {
         if (res.valid) {
           result = true;
-        }else{
-          res.errors.forEach(item => {
-            console.log(item.id,item.errorMessages.join(','))
-          });
         }
+        // else {
+        //   res.errors.forEach(item => {
+        //     console.log(item.id, item.errorMessages.join(','))
+        //   });
+        // }
       })
       .catch((err) => {
         result = false;
@@ -101,8 +102,9 @@ export const useFormUtil = () => {
       },
       taskSalary: {
         rule: [
-          (v) => pattern.positiveInteger.test(v) || "金額輸入不正確",
-          (v) => v >= 10 || "最少需要 10 點超人幣",
+          ruleRequired,
+          (v) => !v || pattern.positiveInteger.test(v) || "金額輸入不正確",
+          (v) => v >= 10 || "任務薪水至少需要 10 點超人幣",
           'checkUserCoin'
         ],
       },

--- a/services/postTaskConfig.js
+++ b/services/postTaskConfig.js
@@ -4,7 +4,7 @@ export const postTaskConfig = {
 
     // 表單提示
     hintMsgs: {
-        counter:{
+        counter: {
             title: _formRules.taskTitle.counter,
             category: '',
             description: _formRules.taskDescription.counter,
@@ -17,11 +17,11 @@ export const postTaskConfig = {
             locationDist: '',
             locationAddress: _formRules.address.counter,
         },
-        hint:{
+        hint: {
             title: _formRules.taskTitle.hint,
             category: '',
             description: _formRules.taskDescription.hint,
-            salary: '最少需要 10 點超人幣',
+            salary: '任務薪水至少需要 10 點超人幣',
             exposurePlan: '',
             contactInfoName: _formRules.name.hint,
             contactInfoPhone: '請輸入有效的手機號碼:09開頭共10碼',
@@ -38,7 +38,7 @@ export const postTaskConfig = {
             title: _formRules.taskTitle.rule,
             category: [],
             description: _formRules.taskDescription.rule,
-            salary: _formRules.taskSalary.rule,
+            salary: [_formRules.taskSalary.rule[1]],
             exposurePlan: [],
             contactInfoName: _formRules.name.rule,
             contactInfoPhone: [rulePhone],
@@ -77,17 +77,17 @@ export const postTaskConfig = {
 
 
     //任務來源狀態
-    currentTaskStatus:{
-        create:'create',//新增任務
-        draft:'draft',//草稿編輯
-        unpublished:'unpublished'//下架編輯
+    currentTaskStatus: {
+        create: 'create',//新增任務
+        draft: 'draft',//草稿編輯
+        unpublished: 'unpublished'//下架編輯
     },
 
     //欄位是否開啟
-    fieldDisadled:{
+    fieldDisadled: {
         //全部都可以編輯
-        init:{
-            title:false,
+        init: {
+            title: false,
             category: false,
             description: false,
             salary: false,
@@ -100,7 +100,7 @@ export const postTaskConfig = {
             locationAddress: false,
         },
         //只有任務說明,任務圖片,聯絡人可以編輯
-        unpublishedEdit:{
+        unpublishedEdit: {
             title: true,
             category: true,
             description: false,


### PR DESCRIPTION
修正:
1. 刊登任務儲存為草稿時，薪水欄位:非必填，且不需要與帳戶超人幣餘額做檢核。
2. '不可超過目前帳戶儲值餘額...' 的檢核規則，只需要加在'published'狀態的規則之下。